### PR TITLE
:sparkles: feat: 게시판 기능에 회원 접근 제한 및 User 테이블 매핑 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,9 +49,10 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'org.modelmapper:modelmapper:3.2.2'
 
+    // spring security test
+    testImplementation 'org.springframework.security:spring-security-test:6.4.2'
 
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
+    tasks.named('test') {
+        useJUnitPlatform()
+    }
 }

--- a/src/main/java/com/example/festimo/domain/admin/mapper/AdminMapper.java
+++ b/src/main/java/com/example/festimo/domain/admin/mapper/AdminMapper.java
@@ -1,6 +1,6 @@
 package com.example.festimo.domain.admin.mapper;
 
-import com.example.festimo.domain.user.entity.Users;
+import com.example.festimo.domain.user.domain.User;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -14,12 +14,12 @@ public interface AdminMapper {
     AdminMapper INSTANCE = Mappers.getMapper(AdminMapper.class);
 
     // Entity → DTO 매핑
-    @Mapping(source = "userId", target = "userId")
+    @Mapping(source = "id", target = "userId")
     @Mapping(source = "userName", target = "userName")
     @Mapping(source = "nickname", target = "nickname")
     @Mapping(source = "email", target = "email")
     @Mapping(source = "role", target = "role")
     @Mapping(source = "gender", target = "gender")
     @Mapping(source = "ratingAvg", target = "ratingAvg")
-    AdminDTO toDto(Users user);
+    AdminDTO toDto(User user);
 }

--- a/src/main/java/com/example/festimo/domain/admin/service/AdminCommunityPostService.java
+++ b/src/main/java/com/example/festimo/domain/admin/service/AdminCommunityPostService.java
@@ -1,6 +1,6 @@
 package com.example.festimo.domain.admin.service;
 
-import com.example.festimo.domain.admin.repository.CommunityPostsRepository;
+import com.example.festimo.domain.post.repository.PostRepository;
 import com.example.festimo.exception.CustomException;
 import com.example.festimo.exception.ErrorCode;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,25 +9,23 @@ import org.springframework.stereotype.Service;
 @Service
 public class AdminCommunityPostService {
 
-    private final CommunityPostsRepository communityPostsRepository;
+    private final PostRepository postRepository;
 
     @Autowired
-    public AdminCommunityPostService(CommunityPostsRepository communityPostsRepository) {
-        this.communityPostsRepository = communityPostsRepository;
+    public AdminCommunityPostService(PostRepository postRepository) {
+        this.postRepository = postRepository;
     }
 
     //게시글 삭제
     public void deletePost(Long postId) {
 
-        boolean exists = communityPostsRepository.existsById(1L);
+        boolean exists = postRepository.existsById(1L);
         System.out.println("게시글 존재 여부: " + exists);
 
-
-        if (!communityPostsRepository.existsById(postId)) {
+        if (!postRepository.existsById(postId)) {
             throw new CustomException(ErrorCode.POST_NOT_FOUND); // 게시글이 없을 경우 예외 발생
         }
 
-
-        communityPostsRepository.deleteById(postId); // 게시글 삭제
+        postRepository.deleteById(postId); // 게시글 삭제
     }
 }

--- a/src/main/java/com/example/festimo/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/festimo/domain/admin/service/AdminService.java
@@ -1,7 +1,7 @@
 package com.example.festimo.domain.admin.service;
 
 import com.example.festimo.domain.admin.dto.AdminUpdateUserDTO;
-import com.example.festimo.domain.user.entity.Users;
+import com.example.festimo.domain.user.domain.User;
 import com.example.festimo.domain.user.repository.UserRepository;
 import com.example.festimo.exception.CustomException;
 import com.example.festimo.exception.ErrorCode;
@@ -36,17 +36,17 @@ public class AdminService {
     public AdminDTO updateUser(Long userId, AdminUpdateUserDTO dto) {
 
         //유저가 존재하는지 확인
-        Users user = userRepository.findById(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() ->new CustomException(ErrorCode.USER_NOT_FOUND));
 
         //업데이트
         user.setUserName(dto.getUserName());
         user.setNickname(dto.getNickname());
         user.setEmail(dto.getEmail());
-        user.setGender(Users.Gender.valueOf(dto.getGender()));
+        user.setGender(User.Gender.valueOf(dto.getGender()));
         user.setRatingAvg(dto.getRatingAvg());
 
-        Users updatedUser = userRepository.save(user);
+        User updatedUser = userRepository.save(user);
 
         return AdminMapper.INSTANCE.toDto(updatedUser);
 
@@ -56,7 +56,7 @@ public class AdminService {
     public void deleteUser(Long userId) {
 
         //유저가 존재하는지 확인
-        Users user = userRepository.findById(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(()->new CustomException(ErrorCode.USER_NOT_FOUND));
 
         userRepository.delete(user);

--- a/src/main/java/com/example/festimo/domain/post/BaseTimeEntity.java
+++ b/src/main/java/com/example/festimo/domain/post/BaseTimeEntity.java
@@ -17,11 +17,11 @@ import java.time.LocalDateTime;
 public abstract class BaseTimeEntity {
 
     @CreatedDate
-    @Column(updatable = false)
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(insertable = false)
+    @Column(name = "updated_at", insertable = false)
     private LocalDateTime updatedAt;
 
     @PrePersist

--- a/src/main/java/com/example/festimo/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/festimo/domain/post/controller/PostController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,8 +22,8 @@ public class PostController {
 
     @Operation(summary = "게시글 등록")
     @PostMapping
-    public ResponseEntity<PostListResponse> createPost(@Valid @RequestBody PostRequest request) {
-        PostListResponse responseDto = postService.createPost(request);
+    public ResponseEntity<PostListResponse> createPost(@Valid @RequestBody PostRequest request, Authentication authentication) {
+        PostListResponse responseDto = postService.createPost(request, authentication);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
@@ -38,8 +39,8 @@ public class PostController {
 
     @Operation(summary = "게시글 상세 조회")
     @GetMapping("/{postId}")
-    public ResponseEntity<PostDetailResponse> getPostById(@PathVariable Long postId) {
-        PostDetailResponse postById = postService.getPostById(postId);
+    public ResponseEntity<PostDetailResponse> getPostById(@PathVariable Long postId, Authentication authentication) {
+        PostDetailResponse postById = postService.getPostById(postId, authentication);
         return ResponseEntity.status(HttpStatus.OK).body(postById);
     }
 
@@ -56,8 +57,9 @@ public class PostController {
     @DeleteMapping("/{postId}")
     public ResponseEntity<Void> deletePost(
             @PathVariable Long postId,
-            @RequestBody DeletePostRequest request) {
-        postService.deletePost(postId, request.getPassword());
+            @RequestBody DeletePostRequest request,
+            Authentication authentication) {
+        postService.deletePost(postId, request.getPassword(), authentication);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
@@ -65,8 +67,9 @@ public class PostController {
     @PostMapping("/{postId}/comments")
     public ResponseEntity<CommentResponse> createComment(
             @PathVariable Long postId,
-            @RequestBody @Valid CommentRequest request) {
-        CommentResponse comment = postService.createComment(postId, request);
+            @RequestBody @Valid CommentRequest request,
+            Authentication authentication) {
+        CommentResponse comment = postService.createComment(postId, request, authentication);
         return ResponseEntity.status(HttpStatus.CREATED).body(comment);
     }
 
@@ -75,9 +78,10 @@ public class PostController {
     public ResponseEntity<CommentResponse> updateComment(
             @PathVariable Long postId,
             @PathVariable Integer sequence,
-            @RequestBody @Valid UpdateCommentRequest request
+            @RequestBody @Valid UpdateCommentRequest request,
+            Authentication authentication
     ) {
-        CommentResponse comment = postService.updateComment(postId, sequence, request);
+        CommentResponse comment = postService.updateComment(postId, sequence, request, authentication);
         return ResponseEntity.status(HttpStatus.OK).body(comment);
     }
 
@@ -85,9 +89,10 @@ public class PostController {
     @DeleteMapping("/{postId}/comments/{sequence}")
     public ResponseEntity<Void> deleteComment(
             @PathVariable Long postId,
-            @PathVariable Integer sequence
+            @PathVariable Integer sequence,
+            Authentication authentication
     ) {
-        postService.deleteComment(postId, sequence);
+        postService.deleteComment(postId, sequence, authentication);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/example/festimo/domain/post/dto/DeletePostRequest.java
+++ b/src/main/java/com/example/festimo/domain/post/dto/DeletePostRequest.java
@@ -2,8 +2,10 @@ package com.example.festimo.domain.post.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class DeletePostRequest {
     private String password;

--- a/src/main/java/com/example/festimo/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/example/festimo/domain/post/dto/PostDetailResponse.java
@@ -25,5 +25,7 @@ public class PostDetailResponse {
     private int views;
     private String createdAt;
     private String updatedAt;
+    private boolean isOwner;
+    private boolean isAdmin;
     private List<CommentResponse> comments = new ArrayList<>();
 }

--- a/src/main/java/com/example/festimo/domain/post/dto/PostListResponse.java
+++ b/src/main/java/com/example/festimo/domain/post/dto/PostListResponse.java
@@ -1,14 +1,12 @@
 package com.example.festimo.domain.post.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class PostListResponse {

--- a/src/main/java/com/example/festimo/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/example/festimo/domain/post/dto/PostRequest.java
@@ -4,18 +4,20 @@ import com.example.festimo.domain.post.entity.PostCategory;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class PostRequest {
     @NotBlank(message = "제목은 필수 입력 항목입니다.")
     @Size(max = 30, message = "제목은 30자 이하로 입력해주세요.")
     private String title;
 
     @NotBlank(message = "작성자는 필수 입력 항목입니다.")
-    @Size(max = 10, message = "작성자는 10자 이하로 입력해주세요.")
+    @Size(max = 15, message = "작성자는 15자 이하로 입력해주세요.")
     private String writer;
 
     @NotBlank(message = "이메일은 필수 입력 항목입니다.")

--- a/src/main/java/com/example/festimo/domain/post/entity/Post.java
+++ b/src/main/java/com/example/festimo/domain/post/entity/Post.java
@@ -1,16 +1,15 @@
 package com.example.festimo.domain.post.entity;
 
 import com.example.festimo.domain.post.BaseTimeEntity;
+import com.example.festimo.domain.user.domain.User;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -39,6 +38,10 @@ public class Post extends BaseTimeEntity {
 
     @Builder.Default
     private int views = 0;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
 
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @OrderBy("sequence asc")

--- a/src/main/java/com/example/festimo/domain/post/service/PostService.java
+++ b/src/main/java/com/example/festimo/domain/post/service/PostService.java
@@ -3,14 +3,15 @@ package com.example.festimo.domain.post.service;
 import com.example.festimo.domain.post.dto.*;
 import com.example.festimo.global.dto.PageResponse;
 import jakarta.validation.Valid;
+import org.springframework.security.core.Authentication;
 
 public interface PostService {
-    PostListResponse createPost(@Valid PostRequest postDto);
+    PostListResponse createPost(@Valid PostRequest postDto, Authentication authentication);
     PageResponse<PostListResponse> getAllPosts(int page, int size);
-    PostDetailResponse getPostById(Long postId);
+    PostDetailResponse getPostById(Long postId, Authentication authentication);
     PostDetailResponse updatePost(Long postId, @Valid UpdatePostRequest request);
-    void deletePost(Long postId, String password);
-    CommentResponse createComment(Long postId, @Valid CommentRequest commentDto);
-    CommentResponse updateComment(Long postId, Integer sequence, @Valid UpdateCommentRequest commentDto);
-    void deleteComment(Long postId, Integer sequence);
+    void deletePost(Long postId, String password, Authentication authentication);
+    CommentResponse createComment(Long postId, @Valid CommentRequest commentDto, Authentication authentication);
+    CommentResponse updateComment(Long postId, Integer sequence, @Valid UpdateCommentRequest commentDto, Authentication authentication);
+    void deleteComment(Long postId, Integer sequence, Authentication authentication);
 }

--- a/src/main/java/com/example/festimo/domain/user/domain/User.java
+++ b/src/main/java/com/example/festimo/domain/user/domain/User.java
@@ -60,7 +60,8 @@ public class User {
     private LocalDateTime modifiedDate;
 
     @Column(name = "rating_avg", nullable = false)
-    private Float ratingAvg;
+    @Builder.Default
+    private Float ratingAvg = 0.0f;
 
     // Enum Classes
     public enum Gender {

--- a/src/main/java/com/example/festimo/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/festimo/domain/user/repository/UserRepository.java
@@ -14,5 +14,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
 
     Optional<User> findByRefreshToken(String refreshToken);
-
-
+}

--- a/src/main/java/com/example/festimo/exception/CommentDeleteAuthorizationException.java
+++ b/src/main/java/com/example/festimo/exception/CommentDeleteAuthorizationException.java
@@ -1,0 +1,7 @@
+package com.example.festimo.exception;
+
+public class CommentDeleteAuthorizationException extends CustomException{
+    public CommentDeleteAuthorizationException() {
+        super(ErrorCode.COMMENT_DELETE_AUTHORIZATION_EXCEPTION);
+    }
+}

--- a/src/main/java/com/example/festimo/exception/CommentUpdateAuthorizationException.java
+++ b/src/main/java/com/example/festimo/exception/CommentUpdateAuthorizationException.java
@@ -1,0 +1,7 @@
+package com.example.festimo.exception;
+
+public class CommentUpdateAuthorizationException extends CustomException {
+    public CommentUpdateAuthorizationException() {
+        super(ErrorCode.COMMENT_UPDATE_AUTHORIZATION_EXCEPTION);
+    }
+}

--- a/src/main/java/com/example/festimo/exception/ErrorCode.java
+++ b/src/main/java/com/example/festimo/exception/ErrorCode.java
@@ -22,10 +22,17 @@ public enum ErrorCode {
     INVALID_APPLICATION_STATUS(HttpStatus.BAD_REQUEST, "신청 상태가 유효하지 않습니다."),
 
     /*
+     * 401 UNAUTHORIZED
+     */
+    UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED, "로그인된 사용자가 아닙니다."),
+
+    /*
      * 403 FORBIDDEN: 권한 없음
      */
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다."),
-
+    POST_DELETE_AUTHORIZATION_EXCEPTION(HttpStatus.FORBIDDEN, "작성자 본인 또는 관리자만 게시글을 삭제할 수 있습니다."),
+    COMMENT_UPDATE_AUTHORIZATION_EXCEPTION(HttpStatus.FORBIDDEN, "작성자 본인만 댓글을 수정할 수 있습니다."),
+    COMMENT_DELETE_AUTHORIZATION_EXCEPTION(HttpStatus.FORBIDDEN, "작성자 본인 또는 관리자만 댓글을 삭제할 수 있습니다."),
 
     /*
      * 404 NOT_FOUND: 리소스를 찾을 수 없음
@@ -51,10 +58,8 @@ public enum ErrorCode {
      * 409 CONFLICT: 사용자의 요청이 서버의 상태와 충돌
      */
     DUPLICATE_APPLICATION(HttpStatus.CONFLICT, "이미 신청된 사용자입니다."),
-
-
-
     ;
+
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/festimo/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/festimo/exception/GlobalExceptionHandler.java
@@ -4,8 +4,10 @@ package com.example.festimo.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.time.LocalDateTime;
@@ -33,15 +35,12 @@ public class GlobalExceptionHandler {
         errorResponse.put("timestamp", LocalDateTime.now());
         errorResponse.put("status", HttpStatus.BAD_REQUEST.value());
 
-
         // 첫 번째 필드 에러만 반환
-
         FieldError fieldError = ex.getBindingResult().getFieldErrors().get(0);
         errorResponse.put("error", fieldError.getDefaultMessage());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
-
 
     @ExceptionHandler(NoContent.class)
     public ResponseEntity<Map<String, Object>> handleNoContent(NoContent ex) {
@@ -50,7 +49,16 @@ public class GlobalExceptionHandler {
         errorResponse.put("status", HttpStatus.OK.value());
         errorResponse.put("message", ex.getMessage());
         return ResponseEntity.status(HttpStatus.OK).body(errorResponse);
+    }
 
+    @ExceptionHandler(UnauthorizedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ResponseEntity<Map<String, Object>> handleUnauthorizedException(UnauthorizedException ex) {
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("timestamp", LocalDateTime.now());
+        errorResponse.put("status", HttpStatus.FORBIDDEN.value());
+        errorResponse.put("error", "회원만 사용할 수 있는 기능입니다. [로그인] 또는 [회원가입] 후 다시 시도해주세요.");
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
     }
 }
 

--- a/src/main/java/com/example/festimo/exception/PostDeleteAuthorizationException.java
+++ b/src/main/java/com/example/festimo/exception/PostDeleteAuthorizationException.java
@@ -1,0 +1,7 @@
+package com.example.festimo.exception;
+
+public class PostDeleteAuthorizationException extends CustomException{
+    public PostDeleteAuthorizationException() {
+        super(ErrorCode.POST_DELETE_AUTHORIZATION_EXCEPTION);
+    }
+}

--- a/src/main/java/com/example/festimo/exception/UnauthorizedException.java
+++ b/src/main/java/com/example/festimo/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.example.festimo.exception;
+
+public class UnauthorizedException extends CustomException {
+    public UnauthorizedException() {
+        super(ErrorCode.UNAUTHORIZED_EXCEPTION);
+    }
+}

--- a/src/main/java/com/example/festimo/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/festimo/global/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -28,20 +29,28 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf().disable()
+                .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests()
-                .requestMatchers(HttpMethod.POST,"/api/register", "/api/login").permitAll()
-                .requestMatchers(
-                        "/v3/api-docs/**",
-                        "/swagger-ui/**",
-                        "/swagger-ui.html"
-                ).permitAll()
-                .requestMatchers("/error").permitAll()// 누구나 가능 , "/oauth2/**"
-                .requestMatchers("/api/admin/**").hasRole("ADMIN")// 권한 기반 접근 제어 관리자만 사용 가능
-                .anyRequest().authenticated()    // 나머지는 로그인한 사용자만
-                .and();
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST, "/api/register", "/api/login").permitAll()
+                        .requestMatchers(
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html"
+                        ).permitAll()
+                        .requestMatchers("/error").permitAll()// 누구나 가능 , "/oauth2/**"
+                        .requestMatchers(HttpMethod.GET, "/api/companions").permitAll() // 게시글 전체 조회는 비회원 허용
+                        .requestMatchers(HttpMethod.GET, "/api/companions/{postId}").authenticated() // 게시글 상세 조회 인증 필요
+                        .requestMatchers(HttpMethod.POST, "/api/companions").authenticated() // 게시글 등록 인증 필요
+                        .requestMatchers(HttpMethod.PUT, "/api/companions/{postId}").authenticated() // 게시글 수정 인증 필요
+                        .requestMatchers(HttpMethod.DELETE, "/api/companions/{postId}").authenticated() // 게시글 삭제 인증 필요
+                        .requestMatchers(HttpMethod.POST, "/api/companions/{postId}/comments").authenticated() // 댓글 등록 인증 필요
+                        .requestMatchers(HttpMethod.PUT, "/api/companions/{postId}/comments/{sequence}").authenticated() // 댓글 수정 인증 필요
+                        .requestMatchers(HttpMethod.DELETE, "/api/companions/{postId}/comments/{sequence}").authenticated() // 댓글 삭제 인증 필요
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN") // 권한 기반 접근 제어 관리자만 사용 가능
+                        .anyRequest().authenticated()    // 나머지는 로그인한 사용자만
+                );
 //                .oauth2Login()
 //                .defaultSuccessUrl("/api/oauth2/success");
 
@@ -53,6 +62,4 @@ public class SecurityConfig {
 
         return http.build();
     }
-
-
 }


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
회원 여부와 권한에 따라 게시판 기능 접근을 제한하도록 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
회원 여부에 따른 접근 제한 구현
- 비회원: 게시판 전체 조회만 가능
- 회원: 게시글 및 댓글 CRUD 작업 수행 가능

Post와 User 테이블 매핑
- 게시글 등록 시 회원의 닉네임(writer) 및 이메일(mail) 정보와 연동
- 댓글 작성 시 회원 정보와 연동

인증 검증 로직 추가
- 비회원 요청 시 UnauthorizedException 반환
- 인증(Authentication) 검증 로직을 헬퍼 메서드로 추출하여 코드 간결화

비회원 요청 시 UnauthorizedException 반환
인증(Authentication) 검증 로직을 헬퍼 메서드로 추출하여 코드 간결화
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
인증 검증 로직 중복 제거 및 헬퍼 메서드화 (validateAuthentication 메서드 추가)
Post와 User 테이블 매핑 검증

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
